### PR TITLE
Fix curl redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or, alternatively, if you have Vagrant installed, just run the following
 (only libvirt/kvm hypervisor is tested, but vagrant box supports VMware
 Desktop/Workstation/Fusion, Parallels, and Hyper-V):
 ```
-curl -O https://git.airshipit.org/cgit/airship-in-a-bottle/plain/Vagrantfile
+curl -LO https://git.airshipit.org/cgit/airship-in-a-bottle/plain/Vagrantfile
 vagrant up
 ```
 


### PR DESCRIPTION
Curl for fetching the Vagrantfile in the documentation is aimed at a redirect, without the L parameter for the curl commant it will not fetch the Vagrantfile but instead a html page instead.