### PR TITLE
Updated pegleg directory upon repo change

### DIFF
--- a/manifests/common/deploy-airship.sh
+++ b/manifests/common/deploy-airship.sh
@@ -83,7 +83,7 @@ PEGLEG_IMAGE=${PEGLEG_IMAGE:-"quay.io/airshipit/pegleg:ac6297eae6c51ab2f13a96978
 PROMENADE_IMAGE=${PROMENADE_IMAGE:-"quay.io/airshipit/promenade:master"}
 
 # Command shortcuts
-PEGLEG=${WORKSPACE}/airship-pegleg/tools/pegleg.sh
+PEGLEG=${WORKSPACE}/pegleg/tools/pegleg.sh
 
 function check_preconditions() {
   set +x


### PR DESCRIPTION
The pegleg repository was recently changed to opendev.org and now the
directory has moved from 'airship-pegleg' to just 'pegleg'. Updated the
command shortcut.